### PR TITLE
fixed naming error

### DIFF
--- a/js/process.js
+++ b/js/process.js
@@ -26,8 +26,8 @@
  */
 
 jQuery(document).ready(function($) {
-  var url = Google_Groups_Subscribe_AJAX.ajaxUrl;
-  var ggs_forms = '.widget.' + Google_Groups_Subscribe_AJAX.class + ' form';
+  var url = Subscribe_Google_Groups_AJAX.ajaxUrl;
+  var ggs_forms = '.widget.' + Subscribe_Google_Groups_AJAX.class + ' form';
 
   // On submit, prevent default action & do AJAX query,
   // display status when finished
@@ -35,15 +35,15 @@ jQuery(document).ready(function($) {
     event.preventDefault();
     $.post(url, $(this).serialize(), function(data) {
       // FIXME: This can be done in a much cleaner way.
-      var id = Google_Groups_Subscribe_AJAX.class + '-' + parseInt(data['widget_number']);
+      var id = Subscribe_Google_Groups_AJAX.class + '-' + parseInt(data['widget_number']);
       var e = $('#' + id + ' .status');
 
       // FIXME: blocks below move when .status is resized
       if (data.status == 'success') {
-        e.text(Google_Groups_Subscribe_AJAX.successMessage);
+        e.text(Subscribe_Google_Groups_AJAX.successMessage);
         e.show().fadeOut(10000);
       } else {
-        e.text(Google_Groups_Subscribe_AJAX.errorMessage);
+        e.text(Subscribe_Google_Groups_AJAX.errorMessage);
         e.show().fadeOut(10000);
       }
     });

--- a/subscribe-google-groups.php
+++ b/subscribe-google-groups.php
@@ -60,7 +60,7 @@ class Plugin {
   //const SUBSCRIPTION_URL = 'https://groups.google.com/forum/#!forum/%s/join';
 
   // Object reference for JavaScript
-  const PLUGIN_OBJ = 'Subscribe_Google_Groups_AJAX';
+  const PLUGIN_OBJ = 'Google_Groups_Subscribe_AJAX';
 
   // i18n language domain
   const DOMAIN = 'subscribe-google-groups';

--- a/subscribe-google-groups.php
+++ b/subscribe-google-groups.php
@@ -60,7 +60,7 @@ class Plugin {
   //const SUBSCRIPTION_URL = 'https://groups.google.com/forum/#!forum/%s/join';
 
   // Object reference for JavaScript
-  const PLUGIN_OBJ = 'Google_Groups_Subscribe_AJAX';
+  const PLUGIN_OBJ = 'Subscribe_Google_Groups_AJAX';
 
   // i18n language domain
   const DOMAIN = 'subscribe-google-groups';


### PR DESCRIPTION
I fixed the `PLUGIN_OBJ` name to match what is in `process.js`. This is what was intended by #3 (without all the Berkeley-specific changes).

The bug was causing me problems with a navigation menu. It wouldn't open at all for small screen sizes. They went away once I fixed the issue and the menu now works fine. This sounds similar to issue #2, so it might solve that too.